### PR TITLE
Revert "[TASK] Set composer alias for version 1 branch"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,6 @@
 	"extra": {
 		"typo3/cms": {
 			"extension-key": "secure_filemount"
-		},
-		"branch-alias": {
-			"dev-1": "1.x-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
This reverts commit 6f169e15b1b593b2d3481d4a878a0ef9268e5a98.

Branch alias for branches with names compatible as
versions are automatically aliased by composer and
packagist.org, which makes it obsolete to define a
custom one specially when it is the same. Reducing
maintenance dept is always a good thing, so remove
it again.
