### PR TITLE
[TASK] Set `2.x-dev` alias for main branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
 	"extra": {
 		"typo3/cms": {
 			"extension-key": "secure_filemount"
+		},
+		"branch-alias": {
+			"dev-main": "2.x-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
composer and packagist.org are capable of
determining branch aliases automatically
for branching looking like version numbers,
but failing to do this for other branches
including the default branch when it does
not look like a version.

To help our beloved dependency management
tool out we need to provide a so-called
branch alias and let it know what alias to
map for the default branch.

Used command(s):

```shell
composer config \
  extra."branch-alias"."dev-main" "2.x-dev"
```
